### PR TITLE
Fix active zone CSS

### DIFF
--- a/SpiritGame.html
+++ b/SpiritGame.html
@@ -344,6 +344,7 @@
           html += `</div>`;
           html += `<button onclick="endTurn()" style="margin-left:0" ${totemBlocked?"disabled":""}>Zug beenden</button>
           <button onclick="exchangeHand()" ${player.hand.length<3||player.energy<1||totemBlocked?"disabled":""}>Alle 3 tauschen (1💠)</button>`;
+          html += `</div>`;
         }
         html += `</div>`;
       }


### PR DESCRIPTION
## Summary
- fix unclosed div so active zone borders no longer wrap entire game

## Testing
- `node - <<'EOF'
const fs=require('fs');const {JSDOM}=require('jsdom');
const html=fs.readFileSync('SpiritGame.html','utf8');
const dom=new JSDOM(html,{runScripts:'dangerously'});
dom.window.setupGame();
const doc=dom.window.document;
console.log('zones', doc.querySelectorAll('.zone').length, 'nested', doc.querySelectorAll('.zone')[0].querySelector('.zone')!==null);
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68667a2e20fc8327a7d2d508f3d029cd